### PR TITLE
React on schedule and workflow dispatch

### DIFF
--- a/action.bash
+++ b/action.bash
@@ -33,18 +33,16 @@ push () {
 	fi
 }
 
+re_docker_tag="^refs/(heads|tags)/([^/]+|[a-z]+/(.*))$"
+
 case "$GITHUB_EVENT_NAME" in
-	workflow_dispatch)
-        ;&
-	schedule)
-		grep -qEe '^refs/heads/.' <<<"$GITHUB_REF"
-		TAG="$(cut -d / -f 3- <<<"$GITHUB_REF")"
-		mkimg "$TAG"
-		push
-		;;
-	release)
-		grep -qEe '^refs/tags/v[0-9]' <<<"$GITHUB_REF"
-		TAG="$(cut -d v -f 2- <<<"$GITHUB_REF")"
+	workflow_dispatch|schedule|release)
+		[[ "$GITHUB_REF" =~ $re_docker_tag ]]
+		if [ -n "${BASH_REMATCH[3]}" ]; then
+			TAG="${BASH_REMATCH[3]}"
+		else
+			TAG="${BASH_REMATCH[2]}"
+		fi
 		mkimg
 		push
 		;;

--- a/action.bash
+++ b/action.bash
@@ -34,12 +34,9 @@ push () {
 }
 
 case "$GITHUB_EVENT_NAME" in
-	pull_request)
-		grep -qEe '^refs/pull/[0-9]+' <<<"$GITHUB_REF"
-		TAG="pr$(grep -oEe '[0-9]+' <<<"$GITHUB_REF")"
-		mkimg
-		;;
-	push)
+	workflow_dispatch)
+        ;&
+	schedule)
 		grep -qEe '^refs/heads/.' <<<"$GITHUB_REF"
 		TAG="$(cut -d / -f 3- <<<"$GITHUB_REF")"
 		mkimg "$TAG"

--- a/get-mods.sh
+++ b/get-mods.sh
@@ -20,7 +20,7 @@ get_special () {
 				REF="$(get_tag)"
 				;;
 			*)
-				if [ -n "$BRANCH" ]; then
+				if [ -n "$BRANCH" ] && git -C dockerweb2-temp show -s --oneline "$BRANCH"; then
 					REF="$BRANCH"
 				else
 					REF="$(get_tag)"


### PR DESCRIPTION
Changes the action so that it handles schedule and workflow-dispatch events. The docker builds for icingaweb2 are now scheduled, which then use the master as base, and won't run on every pull request. Instead they need to be triggered manually for other branches than master.