### PR TITLE
Update wrong github clone path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ on which .ini files there are.
 ## Build it yourself
 
 ```bash
-git clone https://github.com/Icinga/icingaweb2.git
+git clone https://github.com/Icinga/docker-icingaweb2
 #pushd icingaweb2
 #git checkout v2.9.0
 #popd


### PR DESCRIPTION
Fix the URL under the "Build it yourself" Part in README.md