### PR TITLE
Use package locales-all to speed up build times

### DIFF
--- a/deps.Dockerfile
+++ b/deps.Dockerfile
@@ -10,11 +10,7 @@ RUN ["go", "build", "."]
 
 FROM debian:buster-slim
 
-RUN ["bash", "-exo", "pipefail", "-c", "export DEBIAN_FRONTEND=noninteractive; apt-get update; apt-get install --no-install-{recommends,suggests} -y locales; apt-get clean; rm -vrf /var/lib/apt/lists/*"]
-RUN ["perl", "-pi", "-e", "if (/\\bUTF-8$/) { s/^# *// }", "/etc/locale.gen"]
-RUN ["locale-gen", "-j", "4"]
-
-RUN ["bash", "-exo", "pipefail", "-c", "export DEBIAN_FRONTEND=noninteractive; apt-get update; apt-get install --no-install-{recommends,suggests} -y apache2 libapache2-mod-php7.3 php-{imagick,redis} php7.3-{bcmath,bz2,common,curl,dba,enchant,gd,gmp,imap,interbase,intl,json,ldap,mbstring,mysql,odbc,opcache,pgsql,pspell,readline,recode,snmp,soap,sqlite3,sybase,tidy,xml,xmlrpc,xsl,zip}; apt-get clean; rm -vrf /var/lib/apt/lists/*"]
+RUN ["bash", "-exo", "pipefail", "-c", "export DEBIAN_FRONTEND=noninteractive; apt-get update; apt-get install --no-install-{recommends,suggests} -y apache2 libapache2-mod-php7.3 locales-all php-{imagick,redis} php7.3-{bcmath,bz2,common,curl,dba,enchant,gd,gmp,imap,interbase,intl,json,ldap,mbstring,mysql,odbc,opcache,pgsql,pspell,readline,recode,snmp,soap,sqlite3,sybase,tidy,xml,xmlrpc,xsl,zip}; apt-get clean; rm -vrf /var/lib/apt/lists/*"]
 
 COPY --from=entrypoint /entrypoint/entrypoint /entrypoint
 COPY entrypoint/db-init /entrypoint-db-init


### PR DESCRIPTION
Generating all locales took so long, I even had time to create a pull request that installs the packages locales-all instead.

fixes #29