### PR TITLE
adding correct docker image:tag \ as per default docker expects to ad…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This image integrates [Icinga Web 2] into your [Docker] environment.
 
 ## Usage
 
+* specify docker image:tag as defined in dockerhub -> https://hub.docker.com/r/icinga/icingaweb2/tags
+
 ```bash
 docker run --rm -d \
 	-p 8080:8080 \
@@ -43,7 +45,7 @@ docker run --rm -d \
 	-e icingaweb.roles.Administrators.users=icingaadmin \
 	-e icingaweb.roles.Administrators.permissions='*' \
 	-e icingaweb.roles.Administrators.groups=Administrators \
-	icinga/icingaweb2
+	icinga/icingaweb2:master
 ```
 
 The container listens on port 8080 and expects a volume on `/data`.


### PR DESCRIPTION
adding correct docker image:tag
as per default docker expects to add the image tag `latest` to the image which **doesnt exists**

```
root@mon01:~/repos/icinga2# ./start-icinga2web.sh
Unable to find image 'icinga/icingaweb2:latest' locally
docker: Error response from daemon: manifest for icinga/icingaweb2:latest not found:
 manifest unknown: manifest unknown.
See 'docker run --help'.
```

by adding the correct image:tag to the README can avoid issues been created.

```
root@mon01:~/repos/icinga2# ./start-icinga2web.sh
Unable to find image 'icinga/icingaweb2:master' locally
master: Pulling from icinga/icingaweb2
```