### PR TITLE
Use snapshot/nighly branch of icinga-php-* to fix containers with icingadb-web master

### DIFF
--- a/composer.bash
+++ b/composer.bash
@@ -2,7 +2,7 @@
 # Icinga Web 2 Docker image | (c) 2020 Icinga GmbH | GPLv2+
 set -exo pipefail
 
-for d in icingaweb2 icinga-php/* icingaweb2/modules/*; do
+for d in icingaweb2 icingaweb2/modules/*; do
 	pushd "$d"
 
 	if [ -e composer.json ]; then

--- a/get-mods.sh
+++ b/get-mods.sh
@@ -22,7 +22,9 @@ get_special () {
 				REF="$(get_tag)"
 				;;
 			*)
-				if [ -n "$BRANCH" ] && git -C dockerweb2-temp show -s --oneline "$BRANCH"; then
+				if [ "$BRANCH" = master ] && [[ "$2" == icinga-php/* ]]; then
+					REF=snapshot/nightly
+				elif [ -n "$BRANCH" ] && git -C dockerweb2-temp show -s --oneline "$BRANCH"; then
 					REF="$BRANCH"
 				else
 					REF="$(get_tag)"


### PR DESCRIPTION
This PR fixes the `icinga/icingaweb2:master` image to work again with the latest `icingadb-web` `master` which requires a version of `icinga-php-library` newer than the latest release. However, this version is not on branch `master` but on `snapshot/nightly`.

Composer is no longer run on `icinga-php-*` as it's not required and breaks with Composer 1.x.

### `./build.bash ../icingaweb2-support-2.9`
![20210929_14h42m24s_grim](https://user-images.githubusercontent.com/18552/135270936-a99d464c-91e5-4b82-ab76-adb4781b536c.png)

### `./build.bash ../icingaweb2-master master`
![20210929_14h44m05s_grim](https://user-images.githubusercontent.com/18552/135270944-cc785c43-7acb-4fea-b8ab-d883afb0fbe2.png)
