### PR TITLE
Correct utf8 to utf8mb4

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ docker run --rm -d \
 	-e icingaweb.resources.icingaweb_db.dbname=icingaweb \
 	-e icingaweb.resources.icingaweb_db.username=icingaweb \
 	-e icingaweb.resources.icingaweb_db.password=123456 \
-	-e icingaweb.resources.icingaweb_db.charset=utf8 \
+	-e icingaweb.resources.icingaweb_db.charset=utf8mb4 \
 	-e icingaweb.resources.icingadb.type=db \
 	-e icingaweb.resources.icingadb.db=mysql \
 	-e icingaweb.resources.icingadb.host=2001:db8::192.0.2.113 \
 	-e icingaweb.resources.icingadb.dbname=icingadb \
 	-e icingaweb.resources.icingadb.username=icingaweb \
 	-e icingaweb.resources.icingadb.password=123456 \
-	-e icingaweb.resources.icingadb.charset=utf8 \
+	-e icingaweb.resources.icingadb.charset=utf8mb4 \
 	-e icingaweb.roles.Administrators.users=icingaadmin \
 	-e icingaweb.roles.Administrators.permissions='*' \
 	-e icingaweb.roles.Administrators.groups=Administrators \


### PR DESCRIPTION
Corrected utf8 to utf8mb4 as(utf8 still for many mysql or mariadb databases means utf8mb3, which is infamously silently drops a lot of characters from utf8 encoded text. (This is most often seen because it drops smileys from text, as those are most often the characters that users encounter that utf8mb3 drops [like 💩]. This is at best is very annoying, and at worst opens security issues, because it means stuff read back from the database is different (shorter) than stuff written to it)