### PR TITLE
Introduce explicit build mode and clean up code

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -3,7 +3,7 @@
 set -exo pipefail
 
 IW2SRC="$1"
-export MODS_BRANCH="$2"
+export BUILD_MODE="${2:-release}"
 
 if [ -z "$IW2SRC" ]; then
 	cat <<EOF >&2
@@ -22,14 +22,14 @@ docker run --rm -i \
 	-v "${IW2SRC}:/iw2src:ro" \
 	-v "${BLDCTX}:/bldctx:ro" \
 	-v /var/run/docker.sock:/var/run/docker.sock \
-	-e MODS_BRANCH \
+	-e BUILD_MODE \
 	icinga/icingaweb2-builder bash <<EOF
 set -exo pipefail
 
 git -C /iw2src archive --prefix=iw2cp/icingaweb2/ HEAD |tar -xC /
 cd /iw2cp
 
-/bldctx/get-mods.sh "$MODS_BRANCH"
+/bldctx/get-mods.sh "$BUILD_MODE"
 /bldctx/composer.bash
 patch -d icingaweb2 -p0 < /bldctx/icingaweb2.patch
 


### PR DESCRIPTION
This commit introduces an explicit build mode in get-mods.sh that determines how the versions of external modules are selected.

Possible modes are:
 - `release`: chooses latest release for each module
 - `snapshot`: uses a snapshot/development version for each module (if available)

In `action.bash`, the mode is automatically set based on the `GITHUB_REF` variable. For tags starting with `v` (i.e. version tags like `v2.9.0`) it is `release`, other tag names are not supported. For branches it is `snapshot`.

### Tests

#### master
https://github.com/julianbrost/icingaweb2/runs/5550768750?check_suite_focus=true

Uses branch name as tag for the Docker image, selects snapshot mode and selects dev versions:

```
 + MODE=snapshot
+ TAG=master
+ TAG=master
+ mkimg
+ test -n master
+ test -n snapshot
[...]
+ REF=snapshot/nightly
```

#### v42.23
https://github.com/julianbrost/icingaweb2/runs/5550770184?check_suite_focus=true

Uses tag name with `v` prefix trimmed as tag for the Docker image, selects release mode and selects released versions:

```
+ MODE=release
+ TAG=42.23
+ mkimg
+ test -n 42.23
+ test -n release
[...]
+ REF=v0.7.0
```

#### action-test-without-prefix
https://github.com/julianbrost/icingaweb2/runs/5550850774?check_suite_focus=true

Uses branch name as tag for the Docker image, selects snapshot mode and selects dev versions:

```
 + MODE=snapshot
+ TAG=action-test-without-prefix
+ TAG=action-test-without-prefix
+ mkimg
+ test -n action-test-without-prefix
+ test -n snapshot
[...]
+ REF=snapshot/nightly
```

#### feature/action-test-with-prefix
https://github.com/julianbrost/icingaweb2/runs/5550852672?check_suite_focus=true

Uses branch name with `feature/` prefix trimmed as tag for the Docker image, selects snapshot mode and selects dev versions:

```
+ MODE=snapshot
+ TAG=feature/action-test-with-prefix
+ TAG=action-test-with-prefix
+ mkimg
+ test -n action-test-with-prefix
+ test -n snapshot
[...]
+ REF=snapshot/nightly
```

fixes #62
closes #73
closes #78