### PR TITLE
entrypoint: do not lower ini keys

### DIFF
--- a/entrypoint/main.go
+++ b/entrypoint/main.go
@@ -96,7 +96,7 @@ func entrypoint() error {
 								}
 
 								_, errNK := cfg.Section(directive[len(directive)-2]).NewKey(
-									strings.ToLower(directive[len(directive)-1]), kv[1],
+									directive[len(directive)-1], kv[1],
 								)
 								if errNK != nil {
 									return errNK


### PR DESCRIPTION
This is breaks eg [icingaweb2-module-grafana](https://github.com/Mikesch-mp/icingaweb2-module-grafana) which is using some camelCased keys like `enableLink`