### PR TITLE
Add Icinga-stuff to PHP include path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ ENTRYPOINT ["/entrypoint"]
 
 COPY icingaweb2 /usr/share/icingaweb2
 COPY icinga-php /usr/share/icinga-php
+COPY php.ini /etc/php/7.4/cli/conf.d/99-docker.ini
 
 RUN ["ln", "-vs", "/usr/share/icingaweb2/packages/files/apache/icingaweb2.conf", "/etc/apache2/conf-enabled/"]
 RUN ["ln", "-vs", "/usr/share/icingaweb2/bin/icingacli", "/usr/local/bin/"]

--- a/action.Dockerfile
+++ b/action.Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update ;\
 
 COPY --from=clone /actions /actions
 
-COPY action.bash composer.bash Dockerfile get-mods.sh icingaweb2.patch /
+COPY action.bash composer.bash Dockerfile get-mods.sh icingaweb2.patch php.ini /
 COPY entrypoint /entrypoint
 
 CMD ["/action.bash"]

--- a/action.bash
+++ b/action.bash
@@ -16,7 +16,7 @@ mkimg () {
 	/composer.bash
 	patch -d icingaweb2 -p0 < /icingaweb2.patch
 
-	cp -r /entrypoint .
+	cp -r /entrypoint /php.ini .
 	docker build -f /Dockerfile -t "${TARGET}:$TAG" .
 
 	STATE_isPost=1 node /actions/checkout/dist/index.js

--- a/build.bash
+++ b/build.bash
@@ -33,6 +33,6 @@ cd /iw2cp
 /bldctx/composer.bash
 patch -d icingaweb2 -p0 < /bldctx/icingaweb2.patch
 
-cp -r /entrypoint .
+cp -r /entrypoint /bldctx/php.ini .
 docker build -f /bldctx/Dockerfile -t icinga/icingaweb2 .
 EOF

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,2 @@
+[PHP]
+include_path = ".:/usr/share/php:/usr/share/icingaweb2/library:/usr/share/icingaweb2/library/vendor"


### PR DESCRIPTION
so that non-Icinga-stuff, e.g. PHPUnit, can reach Icinga-stuff.