### PR TITLE
allow setting remote_user using an intermediate header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ COPY php.ini /etc/php/7.4/cli/conf.d/99-docker.ini
 
 RUN ["ln", "-vs", "/usr/share/icingaweb2/bin/icingacli", "/usr/local/bin/"]
 RUN ["icingacli", "setup", "config", "webserver", "apache", "--path=/", "--file=/etc/apache2/conf-enabled/icingaweb2.conf"]
+RUN echo 'SetEnvIf X-REMOTE-USER "(.*)" REMOTE_USER=$0' > /etc/apache2/conf-enabled/allow-remote-user.conf
 
 USER www-data
 ENV ICINGAWEB_OFFICIAL_DOCKER_IMAGE 1

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ option = value
 Consult the [Icinga Web 2 configuration documentation]
 on which .ini files there are.
 
+### External authentication
+
+When using `icingaweb.authentication.autologin.backend: external`, the Username needs to be passed in the `X-Remote-User` header.
+
 ## Build it yourself
 
 ```bash


### PR DESCRIPTION
This PR allows to inject a remote user using an intermediate Variable, since  Apache won't let you set Remote_User from the outside.


Closes: #117  