### PR TITLE
build.bash: workaround a bug in docker buildx build CLI

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -26,7 +26,7 @@ if ! docker buildx version; then
 fi
 
 OUR_DIR="$(realpath "$(dirname "$0")")"
-COMMON_ARGS=(-t "icinga/icingaweb2:$TAG" --build-context "icingaweb2-git=$(realpath "$IW2SRC")/.git" --build-arg "BUILD_MODE=$BUILD_MODE" "$OUR_DIR")
+COMMON_ARGS=(-t "icinga/icingaweb2:$TAG" --build-context "icingaweb2-git=$(realpath "$IW2SRC")/.git/" --build-arg "BUILD_MODE=$BUILD_MODE" "$OUR_DIR")
 BUILDX=(docker buildx build --platform "$(cat "${OUR_DIR}/platforms.txt")")
 
 case "$ACTION" in


### PR DESCRIPTION
--build-context dirs seem to have to end with a / to be accepted.