### PR TITLE
Add `Icinga Kubernetes Web`

### DIFF
--- a/get-mods.sh
+++ b/get-mods.sh
@@ -92,3 +92,5 @@ get_mod pdfexport
 get_mod reporting
 get_mod vspheredb
 get_mod x509
+# Icinga Kubernetes Web does not yet have a release, but should also be included:
+MODE=${MODE/release/snapshot} get_altname icinga-kubernetes-web kubernetes


### PR DESCRIPTION
This PR adds `Icinga Kubernetes Web` to the image. Note that there's no
release yet for `Icinga Kubernetes Web`. So for releases of the image,
we have to set `MODE` to `snapshot` right before the module gets cloned.