### PR TITLE
Drop platform linux/arm/v7

### DIFF
--- a/platforms.txt
+++ b/platforms.txt
@@ -1,1 +1,1 @@
-linux/amd64,linux/arm/v7,linux/arm64/v8
+linux/amd64,linux/arm64/v8


### PR DESCRIPTION
to save build time.

Also, it looks weird to provide these, but no ARM32 **packages**.

* CC https://github.com/Icinga/docker-icinga2/pull/127
* CC https://github.com/Icinga/docker-icingadb/pull/72