### PR TITLE
feat: do not remove source files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN git -C /icingaweb2-src archive --prefix=icingaweb2/ HEAD |tar -x
 
 FROM debian:bookworm-slim
 
-RUN ["bash", "-exo", "pipefail", "-c", "export DEBIAN_FRONTEND=noninteractive; apt-get update; apt-get upgrade -y; apt-get install --no-install-{recommends,suggests} -y apache2 ca-certificates libapache2-mod-php8.2 libldap-common locales-all php-{imagick,redis} php8.2-{bcmath,bz2,common,curl,dba,enchant,gd,gmp,imap,interbase,intl,ldap,mbstring,mysql,odbc,opcache,pgsql,pspell,readline,snmp,soap,sqlite3,sybase,tidy,xml,xmlrpc,xsl,zip}; apt-get clean; rm -vrf /var/lib/apt/lists/*"]
+RUN ["bash", "-exo", "pipefail", "-c", "export DEBIAN_FRONTEND=noninteractive; apt-get update; apt-get upgrade -y; apt-get install --no-install-{recommends,suggests} -y apache2 ca-certificates libapache2-mod-php8.2 libldap-common locales-all php-{imagick,redis} php8.2-{bcmath,bz2,common,curl,dba,enchant,gd,gmp,imap,interbase,intl,ldap,mbstring,mysql,odbc,opcache,pgsql,pspell,readline,snmp,soap,sqlite3,sybase,tidy,xml,xmlrpc,xsl,zip}; apt-get clean"]
 
 COPY --from=entrypoint /entrypoint/entrypoint /entrypoint
 COPY entrypoint/db-init /entrypoint-db-init


### PR DESCRIPTION
Do not remove the apt source files to allow users of the package to extend it in a way that fits their needs.
I couldn't find any place that lists this as a best practice, so I assume it might have been a misinterpretation of https://docs.docker.com/build/building/best-practices/#dont-install-unnecessary-packages