### PR TITLE
Build and push release images if manually run on a tag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,13 +25,13 @@ runs:
       run: |
         docker login -u icingaadmin --password-stdin <<<"$PW"
 
-    - if: github.event_name == 'release'
+    - if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag')
       shell: bash
       run: |
         '${{ github.action_path }}/build.bash' . release push "$(tr -d v <<<'${{ github.ref_name }}')"
         '${{ github.action_path }}/mktags.bash' '${{ github.ref_name }}'
 
-    - if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    - if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref_type != 'tag')
       shell: bash
       run: |
         '${{ github.action_path }}/build.bash' . snapshot push "$(tr / - <<<'${{ github.ref_name }}')"


### PR DESCRIPTION
Icinga Web 2 already allows triggering this action manually to re-build snapshot images. GitHub already allows triggering actions manually on tags. Latter can be used for release re-build now.

fixes #138